### PR TITLE
Update lager dependency to most recent version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,8 @@
 {sub_dirs, ["rel"]}.
 
 {deps, [
-    {lager, "3.6.2"},
-    {antidote_pb_codec, "0.0.3"}
+    {antidote_pb_codec, "0.0.3"},
+    lager
 ]}.
 
 {erl_opts, [debug_info, warnings_as_errors, {parse_transform, lager_transform}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,10 @@
 {"1.1.0",
 [{<<"antidote_pb_codec">>,{pkg,<<"antidote_pb_codec">>,<<"0.0.3">>},0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.6.2">>},0}]}.
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.6.9">>},0}]}.
 [
 {pkg_hash,[
  {<<"antidote_pb_codec">>, <<"692A14320C6A78E5906E4EF182D5C09C0BC0CDEFCB3C09338C08FECA3F0226CB">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"2C72950A0E75FFD927DD35BC85EA30E7680A264C4BBD08B328250871AC456CC2">>}]}
+ {<<"lager">>, <<"387BCD836DC0C8AD9C6D90A0E0CE5B29676847950CBC527BCCC194A02028DE8E">>}]}
 ].


### PR DESCRIPTION
Updating lager to the most recent version. This enables the Antidote Erlang client to compile on Erlang 21 on MacOS X.